### PR TITLE
Fix syntax highlighting for on-error

### DIFF
--- a/syntaxes/rosScript.tmLanguage.json
+++ b/syntaxes/rosScript.tmLanguage.json
@@ -64,7 +64,7 @@
       "name": "support.type.rosScript"
     },
     {
-      "match": "\\b(if|else|for|foreach|do|while)(?=\\s|\\{|\\=|\\[|\\()",
+      "match": "\\b(if|else|for|foreach|do|while|on-error)(?=\\s|\\{|\\=|\\[|\\()",
       "name": "keyword.control.rosScript"
     },
     {


### PR DESCRIPTION
Idk how to build and test vscode extensions, but it looked rather straight forward.